### PR TITLE
Added Solid Hatching

### DIFF
--- a/examples/example.js
+++ b/examples/example.js
@@ -3,37 +3,19 @@ const { writeFileSync } = require('fs');
 
 const dxf = new DxfWriter();
 
-// const layer = dxf.addLayer('l_green-Tes“ting*+--/"`\'“"“', Colors.Green)
-// dxf.setCurrentLayerName(layer.name)
+const layer = dxf.addLayer('l_green-Tes“ting*+--/"`\'“"“', Colors.Green)
+dxf.setCurrentLayerName(layer.name)
 
-// const layerBlock = dxf.addLayer('l_red“-Testing*+--/"“`\'"', Colors.Red)
+const layerBlock = dxf.addLayer('l_red“-Testing*+--/"“`\'"', Colors.Red)
 
-// const block = dxf.addBlock('test/in-outer')
-// block.basePoint = point3d(50, 50)
-// block.setLayerName(layerBlock.name)
-// block.addLine(point3d(0, 0), point3d(100, 100))
+const block = dxf.addBlock('test/in-outer')
+block.basePoint = point3d(50, 50)
+block.setLayerName(layerBlock.name)
+block.addLine(point3d(0, 0), point3d(100, 100))
 
-// dxf.addInsert(block.name, point3d(0, 0))
+dxf.addInsert(block.name, point3d(0, 0))
 
-// dxf.setZeroLayerAsCurrent()
-
-const polyline = new HatchPolylineBoundary();
-polyline.add(vertex(0, 0));
-polyline.add(vertex(0, 20));
-polyline.add(vertex(10, 20));
-polyline.add(vertex(10, 0));
-
-const boundary = new HatchBoundaryPaths();
-// Add the defined path
-boundary.addPolylineBoundary(polyline);
-
-const mysolid = gradient({
-    // hatchType: HatchType.SOLID,
-    firstColor: 2,
-    secondColor: 2,
-})
-
-const hatch = dxf.addHatch(boundary, mysolid);
+dxf.setZeroLayerAsCurrent()
 
 const _str = dxf.stringify();
 writeFileSync('examples/example.dxf', _str);

--- a/src/Sections/EntitiesSection/Entities/Hatch.ts
+++ b/src/Sections/EntitiesSection/Entities/Hatch.ts
@@ -324,12 +324,18 @@ export enum GradientType {
 	INVCURVED = 'INVCURVED',
 }
 
+export enum HatchType {
+  SOLID = 0,
+  GRADIENT = 1,
+}
+
 export type HatchGradientOptions_t = {
 	firstColor: number;
 	secondColor?: number;
 	angle?: number;
 	definition?: number;
 	tint?: number;
+  hatchType?: HatchType;
 	type?: GradientType;
 };
 
@@ -381,13 +387,14 @@ export class Hatch extends Entity {
   }
 
   private gradient(dx: Dxfier, fill: HatchGradientOptions_t) {
-    const firstColor = fill.firstColor
+    const firstColor = fill.firstColor ?? 7
     const secondColor = fill.secondColor ?? 7
     const angle = fill.angle ?? 0
     const definition = fill.definition || 0
     const tint = fill.tint ?? 1
+    const hatchType = fill.hatchType ?? 1
     const type = fill.type || GradientType.LINEAR
-    dx.push(450, 1)
+    dx.push(450, hatchType)
     dx.push(451, 0)
     dx.push(460, angle)
     dx.push(461, definition)


### PR DESCRIPTION
I have added solid hatching, by changing the group code 450 to 0
I have added a variable hatchType, when set to solid will export the hatch as solid. For gradient it should be 1. 
Please check once before approving. It's working but I am not sure about the methodology whether it is correct or not.

HOW TO USE:

const polyline = new HatchPolylineBoundary();
polyline.add(vertex(0, 0));
polyline.add(vertex(0, 20));
polyline.add(vertex(10, 20));
polyline.add(vertex(10, 0));

const boundary = new HatchBoundaryPaths();
// Add the defined path
boundary.addPolylineBoundary(polyline);

const mysolid = gradient({
    hatchType: HatchType.SOLID,
    // firstColor: 2,
    // secondColor: 2,
})

const hatch = dxf.addHatch(boundary, mysolid, {
    colorNumber: 30,
});

