### PR TITLE
fix: lwpolyline extrusion

### DIFF
--- a/src/Sections/EntitiesSection/Entities/LWPolyline.ts
+++ b/src/Sections/EntitiesSection/Entities/LWPolyline.ts
@@ -66,5 +66,8 @@ export class LWPolyline extends Entity {
       dx.push(41, v.endWidth)
       dx.push(42, v.bulge)
     }
+    dx.push(210, this.extrusion?.x)
+    dx.push(220, this.extrusion?.y)
+    dx.push(230, this.extrusion?.z)
   }
 }


### PR DESCRIPTION
The original method can be used for arcs, circles, and insert annotations, but this polyline needs to be changed.