### PR TITLE
fix: 3d line bounding box

### DIFF
--- a/src/Internals/BoundingBox.ts
+++ b/src/Internals/BoundingBox.ts
@@ -34,7 +34,9 @@ export class BoundingBox {
     const minX = sp.x < ep.x ? sp.x : ep.x
     const maxY = sp.y > ep.y ? sp.y : ep.y
     const minY = sp.y < ep.y ? sp.y : ep.y
-    return createBoundingBox(point3d(minX, maxY, 0), point3d(maxX, minY, 0))
+    const maxZ = sp.z > ep.z ? sp.z : ep.z
+    const minZ = sp.z < ep.z ? sp.z : ep.z
+    return createBoundingBox(point3d(minX, maxY, minZ), point3d(maxX, minY, maxZ))
   }
 
   static verticesBBox(vertices: vec3_t[]) {


### PR DESCRIPTION

```typescript
        let dxf = new DxfWriter;
        dxf.addLine(point3d(0, 0, 0), point3d(0, 0, 100));
```

This bug causes the DXF of 3D straight lines to fail to open in ACAD.

I don't think this implementation should be provided.
[src\DxfDocument.ts:](https://github.com/dxfjs/writer/blob/08cf5f554c861e853e5d6cad3448b8db8db9aa65/src/DxfDocument.ts#L111)
<view height> should be calculated by developers themselves.
Now in the source code, the Box of many entities is wrong.
If we didn't write <ViewHeight(40)> we wouldn't get this error instead.
