### PR TITLE
fix: avoid viewport height of 0

### DIFF
--- a/src/Sections/TablesSection/Tables/Records/DxfVPort.ts
+++ b/src/Sections/TablesSection/Tables/Records/DxfVPort.ts
@@ -36,7 +36,7 @@ export default class DxfVPort extends DxfRecord {
     dx.push(17, 0)
     dx.push(27, 0)
     dx.push(37, 0)
-    dx.push(40, this.viewHeight)
+    dx.push(40, this.viewHeight || 200)
     dx.push(41, 2) // TODO ?????????
     dx.push(42, 50)
     dx.push(43, 0)


### PR DESCRIPTION
https://github.com/dxfjs/writer/pull/77

When we don't provide Entity's Box function correctly, we hope that it will not make an error, and give a 200 to avoid ACAD not being able to open the file.